### PR TITLE
FIX: handling duplicate torrent response

### DIFF
--- a/lib/transmission-rpc/torrent.rb
+++ b/lib/transmission-rpc/torrent.rb
@@ -111,8 +111,10 @@ module Transmission
 
         @response = Client.request("torrent-add", options)
 
-        if @response['result'] == 'success'
+        if @response['result'] == 'success' && @response['arguments']['torrent-added']
           self.find(@response['arguments']['torrent-added']['id'])
+        elsif @response['result'] == 'success' && @response['arguments']['torrent-duplicate']
+          self.find(@response['arguments']['torrent-duplicate']['id'])
         else
           nil
         end


### PR DESCRIPTION
With the latest RPC protocol when a duplicate torrent is added, it returns a `success` response (with `torrent-duplicate`) arguments instead of `torrent-added`
https://trac.transmissionbt.com/ticket/5614
